### PR TITLE
php-call-site-stats: make it PHP 8 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
 php:
-  - 5.4
+  - 7.4
+  - 8.0
 script: phpunit Tests/

--- a/CallSiteStats.php
+++ b/CallSiteStats.php
@@ -110,5 +110,5 @@ trait CallSiteStats {
       return null;
    }
 
-   abstract protected function isExternalCallSite($file);
+   abstract protected static function isExternalCallSite($file);
 }

--- a/Tests/CallSiteStatsTest.php
+++ b/Tests/CallSiteStatsTest.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . "/../CallSiteStats.php";
 require_once __DIR__ . "/Caller.php";
 
-class CallSiteStatsTest extends PHPUnit_Framework_TestCase {
+class CallSiteStatsTest extends PHPUnit\Framework\TestCase {
    public function testCaptureCallSite() {
       $c = $this->c();
       $site = $c->getCallSite();

--- a/Tests/SummarizeTest.php
+++ b/Tests/SummarizeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SummarizeTest extends PHPUnit_Framework_TestCase {
+class SummarizeTest extends PHPUnit\Framework\TestCase {
    public function testRatios() {
       $this->assertCommandSuccessful(<<<EOT
 blah.php:23 blah 3 7

--- a/summarize.php
+++ b/summarize.php
@@ -63,8 +63,8 @@ class StatsCollection {
          if ($lineData === null){ 
             $lineData = [0,0];
          }
-         $lineData[0] += $parts[$this->column1];
-         $lineData[1] += $parts[$this->column2];
+         $lineData[0] += (int)$parts[$this->column1];
+         $lineData[1] += (int)$parts[$this->column2];
       }
    }
 


### PR DESCRIPTION
This fixes a function declaration bug that PHP 8 complains about, and
adds PHP 7.4 and PHP 8 tests.

cr_req 1
qa_req 0 (I think tests cover the changes)

Connects https://github.com/iFixit/ifixit/issues/37333